### PR TITLE
mesos depends on libsvn and libaur. Need to add 'subversion' and 'apr' to the list of dependencies for mesos.

### DIFF
--- a/mesos/PKGBUILD
+++ b/mesos/PKGBUILD
@@ -10,7 +10,7 @@ arch=('i686' 'x86_64')
 url='http://mesos.apache.org/'
 license=('Apache')
 groups=('science')
-depends=('python2' 'python2-boto' 'curl' 'libsasl' 'leveldb' 'java-environment' 'libunwind' 'python2-protobuf' 'subversion' 'apr')
+depends=('python2' 'python2-boto' 'curl' 'libsasl' 'leveldb' 'java-environment' 'libunwind' 'python2-protobuf' 'subversion' 'apr' 'google-glog')
 makedepends=('java-environment' 'maven' 'http-parser' 'python2-http-parser' 'protobuf' 'google-glog' 'gperftools' 'subversion' 'apr')
 #rc releases
 #source=("https://github.com/apache/mesos/archive/$pkgver${_pkgver_minor}.tar.gz"

--- a/mesos/PKGBUILD
+++ b/mesos/PKGBUILD
@@ -11,7 +11,7 @@ url='http://mesos.apache.org/'
 license=('Apache')
 groups=('science')
 depends=('python2' 'python2-boto' 'curl' 'libsasl' 'leveldb' 'java-environment' 'libunwind' 'python2-protobuf')
-makedepends=('java-environment' 'maven' 'http-parser' 'python2-http-parser' 'protobuf' 'google-glog' 'gperftools')
+makedepends=('java-environment' 'maven' 'http-parser' 'python2-http-parser' 'protobuf' 'google-glog' 'gperftools' 'subversion' 'apr')
 #rc releases
 #source=("https://github.com/apache/mesos/archive/$pkgver${_pkgver_minor}.tar.gz"
 source=("http://www.apache.org/dist/$pkgname/$pkgver/$pkgname-${pkgver}.tar.gz"

--- a/mesos/PKGBUILD
+++ b/mesos/PKGBUILD
@@ -10,7 +10,7 @@ arch=('i686' 'x86_64')
 url='http://mesos.apache.org/'
 license=('Apache')
 groups=('science')
-depends=('python2' 'python2-boto' 'curl' 'libsasl' 'leveldb' 'java-environment' 'libunwind' 'python2-protobuf')
+depends=('python2' 'python2-boto' 'curl' 'libsasl' 'leveldb' 'java-environment' 'libunwind' 'python2-protobuf' 'subversion' 'apr'
 makedepends=('java-environment' 'maven' 'http-parser' 'python2-http-parser' 'protobuf' 'google-glog' 'gperftools' 'subversion' 'apr')
 #rc releases
 #source=("https://github.com/apache/mesos/archive/$pkgver${_pkgver_minor}.tar.gz"

--- a/mesos/PKGBUILD
+++ b/mesos/PKGBUILD
@@ -10,7 +10,7 @@ arch=('i686' 'x86_64')
 url='http://mesos.apache.org/'
 license=('Apache')
 groups=('science')
-depends=('python2' 'python2-boto' 'curl' 'libsasl' 'leveldb' 'java-environment' 'libunwind' 'python2-protobuf' 'subversion' 'apr'
+depends=('python2' 'python2-boto' 'curl' 'libsasl' 'leveldb' 'java-environment' 'libunwind' 'python2-protobuf' 'subversion' 'apr')
 makedepends=('java-environment' 'maven' 'http-parser' 'python2-http-parser' 'protobuf' 'google-glog' 'gperftools' 'subversion' 'apr')
 #rc releases
 #source=("https://github.com/apache/mesos/archive/$pkgver${_pkgver_minor}.tar.gz"


### PR DESCRIPTION
While building the mesos AUR package, I noticed that two dependencies were missing from the PKGBUILD -- apr and subversion.
