### PR TITLE
Add FD limit to riak.service

### DIFF
--- a/riak/riak.service
+++ b/riak/riak.service
@@ -7,6 +7,7 @@ User=riak
 Type=forking
 ExecStart=/opt/riak/bin/riak start
 ExecStop=/opt/riak/bin/riak stop
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Riak will not start if ulimit -n is lower than 65536.
